### PR TITLE
Fix wrong name of recv method in serial server.

### DIFF
--- a/pymodbus3/server/sync.py
+++ b/pymodbus3/server/sync.py
@@ -379,7 +379,7 @@ class ModbusSerialServer(object):
         """
         request = self.socket
         request.send = request.write
-        request.receive = request.read
+        request.recv = request.read
         handler = ModbusSingleRequestHandler(
             request, (self.device, self.device), self
         )


### PR DESCRIPTION
Addresses #9.  There is an attempt to map socket API functions to serial API functions but the name `receive` is used instead of `recv`.