### PR TITLE
RTU framer: two extra Bytes for FramerState.ReadingHeader

### DIFF
--- a/pymodbus3/mei_message.py
+++ b/pymodbus3/mei_message.py
@@ -101,9 +101,13 @@ class ReadDeviceInformationResponse(ModbusResponse):
         :returns: The number of bytes in the response.
         """
         size = 8  # skip the header information
+        if len(data) <= 7:
+            return size + 2
         count = data[7]
 
         while count > 0:
+            if len(data) < size + 2:
+                return size + 2
             _, object_length = struct.unpack('>BB', data[size:size+2])
             size += object_length + 2
             count -= 1

--- a/pymodbus3/server/sync.py
+++ b/pymodbus3/server/sync.py
@@ -379,7 +379,7 @@ class ModbusSerialServer(object):
         """
         request = self.socket
         request.send = request.write
-        request.receive = request.read
+        request.recv = request.read
         handler = ModbusSingleRequestHandler(
             request, (self.device, self.device), self
         )

--- a/pymodbus3/transaction.py
+++ b/pymodbus3/transaction.py
@@ -109,7 +109,12 @@ class ModbusTransactionManager(object):
             # we know how much to read for the fixed size
             # header, so we loop until we have it to guide us.
             elif self.state == FramerState.ReadingHeader:
-                size = self.framer.header_size - len(self.framer.buffer)
+                # size = self.framer.header_size - len(self.framer.buffer)
+                # framing on not yet received stream data does not work.
+                # RTU header_size is 1 (1Byte of ADU for UnitID/SlaveID/Modbus Address)
+                # But need FunctionCode (1Byte) and Byte Count Byte to calculate length of Content Part
+                # [header_size xByte ... unitId/Addr 1Byte][FunctionCode 1Byte][Count 1Byte]
+                size = self.framer.header_size + 2 - len(self.framer.buffer)
                 if size != 0:
                     result = self.client.receive(size)  # off by one on clear
                     if not result:


### PR DESCRIPTION
(https://github.com/gregorschatz/pymodbus3/commit/417820a8045be7cc47a57cf7300fd41311dc2e16 found back in 2015)
Maybe it was just a worse solution for  #4 "Defect in Modbus RTU handling" but, it solves header processing in ReadingHeader state of Framer, not confusing with ReadingContent state.
