### PR TITLE
Fixes in device and payload

### DIFF
--- a/pymodbus3/device.py
+++ b/pymodbus3/device.py
@@ -218,7 +218,7 @@ class ModbusDeviceIdentification(object):
 
         :returns: An iterator of the device information
         """
-        return self.__data.items()
+        return iter(self.__data.items())
 
     def summary(self):
         """ Return a summary of the main items

--- a/pymodbus3/payload.py
+++ b/pymodbus3/payload.py
@@ -57,6 +57,25 @@ class BinaryPayloadBuilder(IPayloadBuilder):
         """
         self._payload = []
 
+    def to_registers(self): # broken function that was added by Stysia
+        ''' Convert the payload buffer into a register
+        layout that can be used as a context block.
+
+        :returns: The register layout to use as a block
+        '''
+        fstring = self._endian + 'H'
+        payload = self.build()
+        return [unpack(fstring, value)[0] for value in payload]
+
+    # def to_coils(self):
+    #     ''' Convert the payload buffer into a coils
+    #     layout that can be used as a context block.
+
+    #     :returns: The coils layout to use as a block
+    #     '''
+    #     return unpack_bitstring(self.build())
+    
+
     def build(self):
         """ Return the payload buffer as a list
 


### PR DESCRIPTION
For python3, device needs to return iter() function not just the items.
Payload was missing one function def to_registers(self), similarly like in pymodbus for python2.